### PR TITLE
Add function to trigger logging when MEM reaches threshold.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ wget -O /opt/loadwatch/loadwatch https://raw.githubusercontent.com/Hummdis/loadw
 
 Defaults:
     THRESH: 50% of real CPU and 5 for virtual machines.
+    MEM_THRESH: 50% of MEM used.
     RETEN: 14 days
 
-Set the `THRESH` and `RETEN` variables at the top of the file to the desired numbers. Remember that the `THRESH` variable will be devided in 2, but rounded to the next highest whole number.
+Set the `THRESH`, `MEM_THRESH`, and `RETEN` variables at the top of the file to
+the desired numbers. Remember that the `THRESH` variable will be devided in 2,
+but rounded to the next highest whole number.
 
 ### Auto-Update
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # LoadWatch
+
 Linux System LoadWatch
 
-LoadWatch - A more lightweight version of Sys-Snap and only triggers when the load is higher than expected or wanted.
+LoadWatch - A more lightweight version of [Sys-Snap](https://github.com/CpanelInc/tech-SysSnapv2) 
+and only triggers when the load is higher than expected or wanted.
 
 #### Version: 1.3.0
 
@@ -9,19 +11,32 @@ LoadWatch - A more lightweight version of Sys-Snap and only triggers when the lo
 
 1. Run the following command, as Root:
 
-       mkdir -p /opt/loadwatch; wget -O /opt/loadwatch/loadwatch https://raw.githubusercontent.com/Hummdis/loadwatch/master/loadwatch && chmod +x /opt/loadwatch/loadwatch
+```bash
+mkdir -p /opt/loadwatch; \
+wget -O /opt/loadwatch/loadwatch https://raw.githubusercontent.com/Hummdis/loadwatch/master/loadwatch \
+&& chmod +x /opt/loadwatch/loadwatch
+```
 
-2. Install `facter`.  You can install it with the proper package manager for your distribution:
- - Arch Linux, Manjaro Linux: `sudo pacman -S facter`
- - Fedora: `sudo dnf install facter`
- - CentOS, RHEL: `sudo yum install epel-release && sudo yum install facter`
- - openSUSE: `sudo zypper install facter`
+2. Install `facter`.  You can install it with the proper package manager for your 
+   distribution:
+	- Arch Linux, Manjaro Linux: `sudo pacman -S facter`
+	- Fedora: `sudo dnf install facter`
+	- CentOS, RHEL: `sudo yum install epel-release && sudo yum install facter`
+	- openSUSE: `sudo zypper install facter`
 
 3. Create the following CRON entry in Root's crontab:
 
-       */1 * * * * /opt/loadwatch/loadwatch
+```
+*/1 * * * * /opt/loadwatch/loadwatch
+```
 
-4. You're done.  LoadWatch will run every minute (unless you change the CRON) and the defaults are to record the system state if the load is above the default of 50% of the CPU maximum ability.  If the server is a virtual machine (i.e. VPS), then the maximum load is 5 with a reported load of 2 or higher. This can be overridden, of course.  It then cleans up any old log files older than 14 days with each run to ensure no logs are kept longer than the defined retention period.
+4. You're done. LoadWatch will run every minute (unless you change the CRON) and
+   the defaults are to record the system state if the load is above the default
+   of 50% of the CPU maximum ability.  If the server is a virtual machine (i.e.
+   VPS), then the maximum load is 5 with a reported load of 2 or higher. This
+   can be overridden, of course.  It then cleans up any old log files older than
+   14 days with each run to ensure no logs are kept longer than the defined
+   retention period.
 
 ## CONFIGURATION
 

--- a/dev.md
+++ b/dev.md
@@ -1,0 +1,13 @@
+---
+title: Development
+date: 2021-09-18 13:42
+tags:
+---
+
+# Development
+
+How to clone repo for testing:
+
+```bash
+git clone --branch {branch-name} https://github.com/kraker/loadwatch.git
+```

--- a/dev.md
+++ b/dev.md
@@ -14,6 +14,12 @@ cd /opt/loadwatch
 chmod +x loadwatch
 ```
 
+Optional oneliner that does the same thing:
+
+```bash
+git clone --branch memory-dev https://github.com/kraker/loadwatch.git /opt/loadwatch && chmod +x /opt/loadwatch/loadwatch
+```
+
 Run script manually with:
 
 ```bash

--- a/dev.md
+++ b/dev.md
@@ -9,5 +9,13 @@ tags:
 How to clone repo for testing:
 
 ```bash
-git clone --branch {branch-name} https://github.com/kraker/loadwatch.git
+git clone --branch {branch-name} https://github.com/kraker/loadwatch.git /opt/loadwatch
+cd /opt/loadwatch
+chmod +x loadwatch
+```
+
+Run script manually with:
+
+```bash
+/opt/loadwatch/loadwatch
 ```

--- a/loadwatch
+++ b/loadwatch
@@ -47,8 +47,10 @@ IFS=$'\n\t'
 # Change these two variables to override the defaults.
 # Load Threshold for doing a dump. Default is 50% of CPU for physical servers and a load average of 8 for virtual servers.
 THRESH=0  # <- Set to 0 so always generates a log for testing. - Alex Kr
+#echo "DEBUG: THRESH=${THRESH}" 1>&2
 # Memory threshold for doing a dump. Default is...
-MEM_THRESH=
+MEM_THRESH=0 # <- Set to 0 so always triggers when testing. - Alex Kr
+#echo "DEBUG: MEM_THRESH=${MEM_THRESH}" 1>&2
 # Retention duration of log files. Default is 14 days.
 RETEN=
 # To turn on auto-updates change this to true
@@ -61,8 +63,12 @@ AUTO_UPDATE='false'
 
 # Variables
 readonly VERSION=1.3.4
-readonly DATE=$(date +%F.%H:%M)
+readonly DATE=$(date +%F_%H.%M) # <- Change formatting to exclude ':' - Alex Kr
 readonly LOAD=$(cat /proc/loadavg | awk '{print $1}')
+#echo "DEBUG: LOAD=${LOAD}" 1>&2
+# MEM is a percentage of memory used expressed as a float. Ex: 26.29
+readonly MEM=$(free -t | awk 'NR == 2 {printf("%.2f"), $3/$2*100}')
+#echo "DEBUG: MEM=${MEM}" 1>&2
 readonly FILE=loadwatch_${DATE}_Load.${LOAD}.log
 readonly DIR=/opt/loadwatch
 readonly LOGDIR=/var/log/loadwatch
@@ -258,17 +264,23 @@ update_check() {
 
 # Main process.
 main() {
+echo 'DEBUG: main() triggered' 1>&2
   echo "LoadWatch v${VERSION} - Timestamp: ${DATE} - Load: ${LOAD}" >> $LOGDIR/$LOG
 
   # Perform update check
-  crontab -l | grep loadwatch | grep root > /dev/null
-  if [ "$?" == 0 ]; then
+#  $(crontab -l | grep loadwatch | grep root > /dev/null)
+# ^ Because this pipe exits as 1 when nothing is found, causes script to exit
+# prematurely in bash hard-mode. 1 is an error. We need to evaluate the 
+# expression in the if statement instead. - Alex Kr
+  if $(crontab -l | grep loadwatch | grep root > /dev/null); then
+#echo "DEBUG: UPDATE NOTICE triggered." 1>&2
     echo "UPDATE NOTICE: Old CRON entry found! Update the Crontab entry to the new path of /opt/loadwatch/loadwatch" >> $LOGDIR/$LOG
   fi
   update_check
 
   # Perform the actual work.
   if [ -z "${THRESH}" ]; then
+#echo "DEBUG: THRESH is *not* set." 1>&2
     if [ virtual_check ]; then
       MAX=5
     elif [ lscpu_check ]; then
@@ -277,18 +289,31 @@ main() {
       MAX=$(cat /proc/cpuinfo | grep "cpu cores" | tail -1 | awk '{print $4}')
     fi
     THRESH=$(expr $MAX / 2)
+  elif [ -z "${MEM_THRESH}" ]; then
+#echo "DEBUG: MEM_THRESH is *not* set." 1>&2
+    MEM_THRESH=50
+  else
+#echo "DEBUG: THRESH and MEM_THRESH are both set." 1>&2
   fi
 
   # Written this way is allows comparison of decimal numbers.
+#echo "DEBUG: LOAD Expression evaluates to: $(echo "${LOAD} > ${THRESH}" | bc -l)" 1>&2
+#echo "DEBUG: MEM expression evaluates to: $(echo "${MEM} > ${MEM_THRESH}" | bc -l)" 1>&2
   if (( $(echo "${LOAD} > ${THRESH}" | bc -l) )); then
+#echo "DEBUG: THRESH is < LOAD." 1>&2
     dump_stats
+  elif (( $(echo "${MEM} > ${MEM_THRESH}" | bc -l) )); then
+#echo "DEBUG: MEM is < MEM_THRESH." 1>&2
+    dump_stats
+  else
+#echo "DEBUG: Neither LOAD > THRESH nor MEM > MEM_THRESH" 1>&2
   fi
 
   # Always perform cleaup to keep with retention settings.
   cleanup_files
 }
 
-case $1 in
+case ${1-default} in  # Set a default expansion to avoid failures in bash hard-mode
   update)
     echo "Running LoadWatch manual update..."
     wget -O $DIR/loadwatch ${RAWURL}

--- a/loadwatch
+++ b/loadwatch
@@ -47,11 +47,9 @@ IFS=$'\n\t'
 # Change these two variables to override the defaults.
 # Load Threshold for doing a dump. Default is 50% of CPU for physical servers and a load average of 8 for virtual servers.
 THRESH= 
-# <- Set to 0 so always generates a log for testing. - Alex Kr
 #echo "DEBUG: THRESH=${THRESH}" 1>&2
-# Memory threshold for doing a dump. Default is...
+# Memory threshold for doing a dump. Default is 50% used MEM.
 MEM_THRESH= 
-# <- Set to 0 so always triggers when testing. - Alex Kr
 #echo "DEBUG: MEM_THRESH=${MEM_THRESH}" 1>&2
 # Retention duration of log files. Default is 14 days.
 RETEN=
@@ -300,7 +298,7 @@ main() {
   fi
 
   # Written this way is allows comparison of decimal numbers.
-#echo "DEBUG: LOAD Expression evaluates to: $(echo "${LOAD} > ${THRESH}" | bc -l)" 1>&2
+#echo "DEBUG: LOAD expression evaluates to: $(echo "${LOAD} > ${THRESH}" | bc -l)" 1>&2
 #echo "DEBUG: MEM expression evaluates to: $(echo "${MEM} > ${MEM_THRESH}" | bc -l)" 1>&2
   if (( $(echo "${LOAD} > ${THRESH}" | bc -l) )); then
 #echo "DEBUG: THRESH is < LOAD." 1>&2
@@ -316,7 +314,7 @@ main() {
   cleanup_files
 }
 
-case ${1-default} in  # Set a default expansion to avoid failures in bash hard-mode
+case ${1-default} in  # Set a default expansion to avoid failures in bash strict-mode
   update)
     echo "Running LoadWatch manual update..."
     wget -O $DIR/loadwatch ${RAWURL}

--- a/loadwatch
+++ b/loadwatch
@@ -41,10 +41,12 @@
 # Change these two variables to override the defaults.
 # Load Threshold for doing a dump. Default is 50% of CPU for physical servers and a load average of 8 for virtual servers.
 THRESH=
+# Memory threshold for doing a dump. Default is...
+MEM_THRESH=
 # Retention duration of log files. Default is 14 days.
 RETEN=
-# By default, LoadWatch auto-updates. To turn this off, change this to "false".
-AUTO_UPDATE='true'
+# To turn on auto-updates change this to true
+AUTO_UPDATE='false'
 
 
 ########################################################################
@@ -65,227 +67,227 @@ readonly DIVIDER="=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 # Make sure our operating directory exists.  By default, this file runs from within this directory, but is not required.
 if [ ! -d $DIR ]; then
-    mkdir -p $DIR
+  mkdir -p $DIR
 fi
 
 if [ ! -d $LOGDIR ]; then
-    mkdir -p $LOGDIR
+  mkdir -p $LOGDIR
 fi
 
 # Gather the system stats and put them into the log.
 dump_stats() {
-    echo -e "ALERT: Loadwatch Triggered! - Timestamp: ${DATE} - Load: ${LOAD} - Log: ${DIR}/${FILE}" >> $LOGDIR/$LOG
-    echo -e "=-=-=-=-=-=    BEGIN LOADWATCH REPORT - ${VERSION}  =-=-=-=-=-=\n" > $LOGDIR/$FILE
-	echo $DATE >> $LOGDIR/$FILE
-	echo $LOAD >> $LOGDIR/$FILE
-    echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
-	echo "FREE RAM" >> $LOGDIR/$FILE
-	free -m >> $LOGDIR/$FILE
-	echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
-	echo "MySQL PROCCESS LIST" >> $LOGDIR/$FILE
-    mysqladmin processlist stat >> $LOGDIR/$FILE
-	echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
-	echo "APACHE STATUS AND CONNECTIONS PER DOMAIN" >> $LOGDIR/$FILE
-    /usr/sbin/apachectl fullstatus | tee -a $LOGDIR/$FILE | awk '{print $14}' | sort |sed -e 's/^[[:blank:]]*#.*//' -e '/^[[:blank:]]*$/d' | uniq -c | sort -n | grep -v VHost >> $LOGDIR/$FILE
-	echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
-	echo "NETSTAT DETAILS" >> $LOGDIR/$FILE
-    netstat -tn 2>/dev/null | grep :80 | awk '{print $5}' | cut -d: -f1 | sort | uniq -c | sort -nr | head >> $LOGDIR/$FILE
-	echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
-	echo "TOP STATUS" >> $LOGDIR/$FILE
-	# Make sure the COLUMNS system value is set to 1000 before running TOP to make sure we get the full command being run.
-	COLUMNS=1000; top -bcn 1 >> $LOGDIR/$FILE
-	echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
-	echo "PROCESS LIST" >> $LOGDIR/$FILE
-    ps auxf >> $LOGDIR/$FILE
-	echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
-	echo "EXIM STATS" >> $LOGDIR/$FILE
-    /usr/sbin/exiwhat >> $LOGDIR/$FILE
-	echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
-	echo "IOSTAT DETAILS" >> $LOGDIR/$FILE
-    iostat >> $LOGDIR/$FILE
-	echo -e "\n=-=-=-=-=-=   END OF REPORT   =-=-=-=-=-=" >> $LOGDIR/$FILE
+  echo -e "ALERT: Loadwatch Triggered! - Timestamp: ${DATE} - Load: ${LOAD} - Log: ${DIR}/${FILE}" >> $LOGDIR/$LOG
+  echo -e "=-=-=-=-=-=    BEGIN LOADWATCH REPORT - ${VERSION}  =-=-=-=-=-=\n" > $LOGDIR/$FILE
+  echo $DATE >> $LOGDIR/$FILE
+  echo $LOAD >> $LOGDIR/$FILE
+  echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
+  echo "FREE RAM" >> $LOGDIR/$FILE
+  free -m >> $LOGDIR/$FILE
+  echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
+  echo "MySQL PROCCESS LIST" >> $LOGDIR/$FILE
+  mysqladmin processlist stat >> $LOGDIR/$FILE
+  echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
+  echo "APACHE STATUS AND CONNECTIONS PER DOMAIN" >> $LOGDIR/$FILE
+  /usr/sbin/apachectl fullstatus | tee -a $LOGDIR/$FILE | awk '{print $14}' | sort |sed -e 's/^[[:blank:]]*#.*//' -e '/^[[:blank:]]*$/d' | uniq -c | sort -n | grep -v VHost >> $LOGDIR/$FILE
+  echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
+  echo "NETSTAT DETAILS" >> $LOGDIR/$FILE
+  netstat -tn 2>/dev/null | grep :80 | awk '{print $5}' | cut -d: -f1 | sort | uniq -c | sort -nr | head >> $LOGDIR/$FILE
+  echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
+  echo "TOP STATUS" >> $LOGDIR/$FILE
+  # Make sure the COLUMNS system value is set to 1000 before running TOP to make sure we get the full command being run.
+  COLUMNS=1000; top -bcn 1 >> $LOGDIR/$FILE
+  echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
+  echo "PROCESS LIST" >> $LOGDIR/$FILE
+  ps auxf >> $LOGDIR/$FILE
+  echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
+  echo "EXIM STATS" >> $LOGDIR/$FILE
+  /usr/sbin/exiwhat >> $LOGDIR/$FILE
+  echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
+  echo "IOSTAT DETAILS" >> $LOGDIR/$FILE
+  iostat >> $LOGDIR/$FILE
+  echo -e "\n=-=-=-=-=-=   END OF REPORT   =-=-=-=-=-=" >> $LOGDIR/$FILE
 }
 
 # Perform cleanup. Check if the user has set a value. If not, default to 14.
 cleanup_files() {
-    if [ -z "${RETEN}" ]; then
-        RETEN=14
-    fi
+  if [ -z "${RETEN}" ]; then
+    RETEN=14
+  fi
 
-    # Starting in version 1.3.0, the log path is /var/log/loadwatch.  Move any log
-    # files from the old path to the new.  If the checklog file exists here then
-    # all other files exist here as well, so move them all.
-    if test -f /root/loadwatch/checklog; then
-        mv /root/loadwatch/checklog* $LOGDIR/ > /dev/null 2>&1
-        mv /root/loadwatch/loadwatch_* $LOGDIR/ > /dev/null 2>&1
-    fi
-    
-    # Don't break the current CRON entry, make a symlink, if the old path exists.
-    if [ -h /root/loadwatch/loadwatch ]; then
-        rm -f /root/loadwatch/loadwatch
-        ln -s $DIR/loadwatch /root/loadwatch/loadwatch
-        touch /root/loadwatch/01_UPDATE_CRON_BEFORE_DELETING_SYMLINK
-    fi
-    
-    # Cleanup the loadwatch_ log files.
-    find $LOGDIR -name 'loadwatch_*' -mtime +${RETEN} -exec rm -f {} \;
+  # Starting in version 1.3.0, the log path is /var/log/loadwatch.  Move any log
+  # files from the old path to the new.  If the checklog file exists here then
+  # all other files exist here as well, so move them all.
+  if test -f /root/loadwatch/checklog; then
+    mv /root/loadwatch/checklog* $LOGDIR/ > /dev/null 2>&1
+    mv /root/loadwatch/loadwatch_* $LOGDIR/ > /dev/null 2>&1
+  fi
 
-	# Rotate the 'checklog' file every 24 hours and compress it.  Then, delete any older than the retention period.
-	if [ $(date +%H%M) == 0000 ]; then
-		NEWLOG=${LOGDIR}/${LOG}.$(date -d "yesterday" +%Y-%m-%d)
-		mv ${LOGDIR}/${LOG} ${NEWLOG}
-		touch $LOGDIR
-		gzip -f -9 ${NEWLOG}
-	fi
-	find $LOGDIR -type f -name '${LOG.}*' -mtime +${RETEN} -exec rm -f {} \;
+  # Don't break the current CRON entry, make a symlink, if the old path exists.
+  if [ -h /root/loadwatch/loadwatch ]; then
+    rm -f /root/loadwatch/loadwatch
+    ln -s $DIR/loadwatch /root/loadwatch/loadwatch
+    touch /root/loadwatch/01_UPDATE_CRON_BEFORE_DELETING_SYMLINK
+  fi
+
+  # Cleanup the loadwatch_ log files.
+  find $LOGDIR -name 'loadwatch_*' -mtime +${RETEN} -exec rm -f {} \;
+
+  # Rotate the 'checklog' file every 24 hours and compress it.  Then, delete any older than the retention period.
+  if [ $(date +%H%M) == 0000 ]; then
+    NEWLOG=${LOGDIR}/${LOG}.$(date -d "yesterday" +%Y-%m-%d)
+    mv ${LOGDIR}/${LOG} ${NEWLOG}
+    touch $LOGDIR
+    gzip -f -9 ${NEWLOG}
+  fi
+  find $LOGDIR -type f -name '${LOG.}*' -mtime +${RETEN} -exec rm -f {} \;
 
 }
 
 # Check for facter, needed to determine if system is physical or virtual. Abort if it's missing.
 facter_check() {
-	facter > /dev/null 2>&1
-	if [ $? -ne 0 ]; then
-		echo "Facter is not installed. Please install it with the proper package manager for your distribution:"
-		echo -e "\tsudo pacman -S facter"
-		echo -e "\tsudo dnf install facter"
-		echo -e "\tyum install epel-release && yum install fracter"
-		echo -e "\tzypper install facter"
-		echo -e "\n\nExiting."
-		exit 1
-	fi
+  facter > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "Facter is not installed. Please install it with the proper package manager for your distribution:"
+    echo -e "\tsudo pacman -S facter"
+    echo -e "\tsudo dnf install facter"
+    echo -e "\tyum install epel-release && yum install fracter"
+    echo -e "\tzypper install facter"
+    echo -e "\n\nExiting."
+    exit 1
+  fi
 }
 
 # Perform the actual virtual machine check
 virtual_check() {
-	facter_check
-    if [ $(facter | grep is_virtual | awk '{print $3}') == 'true' ]; then
-        return 0 # True
-    else
-        return 1 # False
-    fi
+  facter_check
+  if [ $(facter | grep is_virtual | awk '{print $3}') == 'true' ]; then
+    return 0 # True
+  else
+    return 1 # False
+  fi
 }
 
 # See if the system can run the lscpu command.
 lscpu_check() {
-	lscpu > /dev/null 2>&1
-	if [ $? -eq 0 ]; then
-		return 0 # True
-	else
-		return 1 # False
-	fi
+  lscpu > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    return 0 # True
+  else
+    return 1 # False
+  fi
 }
 
 # Compare the versions of LoadWatch
 compare_versions() {
-    # This will return the following numbers for the two arguments passed.
-    # 0 if $1 = $2
-    # 1 if $1 > $2
-    # 2 if $1 < $2
+  # This will return the following numbers for the two arguments passed.
+  # 0 if $1 = $2
+  # 1 if $1 > $2
+  # 2 if $1 < $2
 
-    if [[ $1 == $2 ]]; then
-        return 0
+  if [[ $1 == $2 ]]; then
+    return 0
+  fi
+
+  local IFS=.
+  local i ver1=($1) ver2=($2)
+  # Fill empty fields in ver1 with zeros
+  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
+    ver1[i]=0
+  done
+
+  for ((i=0; i<${#ver1[@]}; i++)); do
+    if [[ -z ${ver2[i]} ]]; then
+      # Fill empty fields in ver2 with zeros
+      ver2[i]=0
     fi
 
-    local IFS=.
-    local i ver1=($1) ver2=($2)
-    # Fill empty fields in ver1 with zeros
-    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
-        ver1[i]=0
-    done
+    if ((10#${ver1[i]} > 10#${ver2[i]})); then
+      return 1
+    fi
 
-    for ((i=0; i<${#ver1[@]}; i++)); do
-        if [[ -z ${ver2[i]} ]]; then
-            # Fill empty fields in ver2 with zeros
-            ver2[i]=0
-        fi
+    if ((10#${ver1[i]} < 10#${ver2[i]})); then
+      return 2
+    fi
+  done
 
-        if ((10#${ver1[i]} > 10#${ver2[i]})); then
-            return 1
-        fi
-
-        if ((10#${ver1[i]} < 10#${ver2[i]})); then
-            return 2
-        fi
-    done
-
-    return 0
+  return 0
 }
 
 # Update Check
 update_check() {
-    # Perform update check
-    # Only download the file every 6 hours to reduce the number of times this is done.
-    if [[ ! -e ${TMPFILE} ]]; then
-        wget -O ${TMPFILE} -q ${RAWURL}
-    elif test `find ${TMPFILE} -mmin +360`; then
-        rm -f ${TMPFILE}
-        wget -O ${TMPFILE} -q ${RAWURL}
-    fi
-    readonly NEW_VER=$(cat ${TMPFILE} | grep -m 1 "VERSION=" | cut -d = -f 2)
-    compare_versions ${NEW_VER} ${VERSION}
-    case $? in
-        0)  # No update available. Do nothing.
-            ;;
-        1)  # If Auto Update is enabled, update. Otherwise, report a new version, but do nothing else.
-            if [[ $AUTO_UPDATE == 'true' ]]; then
-                echo "Update Check - Auto Update enabled.  Updating to v${NEW_VER}" >> $LOGDIR/$LOG
-                mv $TMPFILE $DIR/loadwatch
-                chmod +x $DIR/loadwatch
-            else
-                echo "Update Check - LoadWatch v${NEW_VER} available. Auto Update disabled." >> $LOGDIR/$LOG
-            fi
-            ;;
-        2)  # The public version is older than the current version.
-            echo "Update Check - Running LoadWatch version is ${VERSION}, but published version is ${NEW_VER}. Is this a pre-release?" >> $LOGDIR/$LOG
-            ;;
-        *)  # All other values are invalid. Report, but don't cause the program to abort.
-            echo "Update Check - LoadWatch Update Check returned an invalid code ($?). Skipping update." >> $LOGDIR/$LOG
-            ;;
-    esac
+  # Perform update check
+  # Only download the file every 6 hours to reduce the number of times this is done.
+  if [[ ! -e ${TMPFILE} ]]; then
+    wget -O ${TMPFILE} -q ${RAWURL}
+  elif test `find ${TMPFILE} -mmin +360`; then
+    rm -f ${TMPFILE}
+    wget -O ${TMPFILE} -q ${RAWURL}
+  fi
+  readonly NEW_VER=$(cat ${TMPFILE} | grep -m 1 "VERSION=" | cut -d = -f 2)
+  compare_versions ${NEW_VER} ${VERSION}
+  case $? in
+    0)  # No update available. Do nothing.
+      ;;
+    1)  # If Auto Update is enabled, update. Otherwise, report a new version, but do nothing else.
+      if [[ $AUTO_UPDATE == 'true' ]]; then
+        echo "Update Check - Auto Update enabled.  Updating to v${NEW_VER}" >> $LOGDIR/$LOG
+        mv $TMPFILE $DIR/loadwatch
+        chmod +x $DIR/loadwatch
+      else
+        echo "Update Check - LoadWatch v${NEW_VER} available. Auto Update disabled." >> $LOGDIR/$LOG
+      fi
+      ;;
+    2)  # The public version is older than the current version.
+      echo "Update Check - Running LoadWatch version is ${VERSION}, but published version is ${NEW_VER}. Is this a pre-release?" >> $LOGDIR/$LOG
+      ;;
+    *)  # All other values are invalid. Report, but don't cause the program to abort.
+      echo "Update Check - LoadWatch Update Check returned an invalid code ($?). Skipping update." >> $LOGDIR/$LOG
+      ;;
+  esac
 }
 
 # Main process.
 main() {
-	echo "LoadWatch v${VERSION} - Timestamp: ${DATE} - Load: ${LOAD}" >> $LOGDIR/$LOG
+  echo "LoadWatch v${VERSION} - Timestamp: ${DATE} - Load: ${LOAD}" >> $LOGDIR/$LOG
 
-    # Perform update check
-    crontab -l | grep loadwatch | grep root > /dev/null
-    if [ "$?" == 0 ]; then
-        echo "UPDATE NOTICE: Old CRON entry found! Update the Crontab entry to the new path of /opt/loadwatch/loadwatch" >> $LOGDIR/$LOG
+  # Perform update check
+  crontab -l | grep loadwatch | grep root > /dev/null
+  if [ "$?" == 0 ]; then
+    echo "UPDATE NOTICE: Old CRON entry found! Update the Crontab entry to the new path of /opt/loadwatch/loadwatch" >> $LOGDIR/$LOG
+  fi
+  update_check
+
+  # Perform the actual work.
+  if [ -z "${THRESH}" ]; then
+    if [ virtual_check ]; then
+      MAX=5
+    elif [ lscpu_check ]; then
+      MAX=$(lscpu | grep "per socket:" | awk '{print $4}')
+    else
+      MAX=$(cat /proc/cpuinfo | grep "cpu cores" | tail -1 | awk '{print $4}')
     fi
-    update_check
+    THRESH=$(expr $MAX / 2)
+  fi
 
-    # Perform the actual work.
-	if [ -z "${THRESH}" ]; then
-		if [ virtual_check ]; then
-			MAX=5
-		elif [ lscpu_check ]; then
-			MAX=$(lscpu | grep "per socket:" | awk '{print $4}')
-		else
-			MAX=$(cat /proc/cpuinfo | grep "cpu cores" | tail -1 | awk '{print $4}')
-		fi
-		THRESH=$(expr $MAX / 2)
-	fi
-	
-    # Written this way is allows comparison of decimal numbers.
-	if (( $(echo "${LOAD} > ${THRESH}" | bc -l) )); then
-		dump_stats
-	fi
-    
-    # Always perform cleaup to keep with retention settings.
-    cleanup_files
+  # Written this way is allows comparison of decimal numbers.
+  if (( $(echo "${LOAD} > ${THRESH}" | bc -l) )); then
+    dump_stats
+  fi
+
+  # Always perform cleaup to keep with retention settings.
+  cleanup_files
 }
 
 case $1 in
-    update)
-        echo "Running LoadWatch manual update..."
-        wget -O $DIR/loadwatch ${RAWURL}
-        chmod +x $DIR/loadwatch
-        echo "LoadWatch update complete."
-        ;;
-    *)
-        main
-        ;;
+  update)
+    echo "Running LoadWatch manual update..."
+    wget -O $DIR/loadwatch ${RAWURL}
+    chmod +x $DIR/loadwatch
+    echo "LoadWatch update complete."
+    ;;
+  *)
+    main
+    ;;
 esac
 
 exit 0

--- a/loadwatch
+++ b/loadwatch
@@ -40,7 +40,7 @@
 
 # Change these two variables to override the defaults.
 # Load Threshold for doing a dump. Default is 50% of CPU for physical servers and a load average of 8 for virtual servers.
-THRESH=
+THRESH=0  # <- Set to 0 so always generates a log for testing. - Alex Kr
 # Memory threshold for doing a dump. Default is...
 MEM_THRESH=
 # Retention duration of log files. Default is 14 days.
@@ -65,13 +65,18 @@ readonly TMPFILE=${DIR}/.loadwatch
 readonly RAWURL=https://raw.githubusercontent.com/Hummdis/loadwatch/master/loadwatch
 readonly DIVIDER="=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 
-# Make sure our operating directory exists.  By default, this file runs from within this directory, but is not required.
+# Make sure our operating directory exists.  By default, this file runs from 
+# within this directory, but is not required.
 if [ ! -d $DIR ]; then
   mkdir -p $DIR
+else
+  echo 'DEBUG: $DIR exists.' 1>&2
 fi
 
 if [ ! -d $LOGDIR ]; then
   mkdir -p $LOGDIR
+else
+  echo 'DEBUG: $LOGDIR exists.' 1>&2
 fi
 
 # Gather the system stats and put them into the log.

--- a/loadwatch
+++ b/loadwatch
@@ -46,10 +46,12 @@ IFS=$'\n\t'
 
 # Change these two variables to override the defaults.
 # Load Threshold for doing a dump. Default is 50% of CPU for physical servers and a load average of 8 for virtual servers.
-THRESH=0  # <- Set to 0 so always generates a log for testing. - Alex Kr
+THRESH= 
+# <- Set to 0 so always generates a log for testing. - Alex Kr
 #echo "DEBUG: THRESH=${THRESH}" 1>&2
 # Memory threshold for doing a dump. Default is...
-MEM_THRESH=0 # <- Set to 0 so always triggers when testing. - Alex Kr
+MEM_THRESH= 
+# <- Set to 0 so always triggers when testing. - Alex Kr
 #echo "DEBUG: MEM_THRESH=${MEM_THRESH}" 1>&2
 # Retention duration of log files. Default is 14 days.
 RETEN=
@@ -264,7 +266,7 @@ update_check() {
 
 # Main process.
 main() {
-echo 'DEBUG: main() triggered' 1>&2
+#echo 'DEBUG: main() triggered' 1>&2
   echo "LoadWatch v${VERSION} - Timestamp: ${DATE} - Load: ${LOAD}" >> $LOGDIR/$LOG
 
   # Perform update check
@@ -289,11 +291,12 @@ echo 'DEBUG: main() triggered' 1>&2
       MAX=$(cat /proc/cpuinfo | grep "cpu cores" | tail -1 | awk '{print $4}')
     fi
     THRESH=$(expr $MAX / 2)
-  elif [ -z "${MEM_THRESH}" ]; then
-#echo "DEBUG: MEM_THRESH is *not* set." 1>&2
+  fi
+
+  if [ -z "${MEM_THRESH}" ]; then
+#echo "DEBUG: MEM_THRESH is *not* set." >&2
     MEM_THRESH=50
-  else
-#echo "DEBUG: THRESH and MEM_THRESH are both set." 1>&2
+#echo "DEBUG: MEM_THRESH=${MEM_THRESH}" >&2
   fi
 
   # Written this way is allows comparison of decimal numbers.
@@ -305,7 +308,7 @@ echo 'DEBUG: main() triggered' 1>&2
   elif (( $(echo "${MEM} > ${MEM_THRESH}" | bc -l) )); then
 #echo "DEBUG: MEM is < MEM_THRESH." 1>&2
     dump_stats
-  else
+#  else
 #echo "DEBUG: Neither LOAD > THRESH nor MEM > MEM_THRESH" 1>&2
   fi
 

--- a/loadwatch
+++ b/loadwatch
@@ -38,6 +38,12 @@
 # Set the THRESH and RETEN variables at the top of the file to the desired numbers to override the defaults.
 ####
 
+# Unofficial "Bash Strict Mode"
+# Use this unless you love debugging
+# See: http://redsymbol.net/articles/unofficial-bash-strict-mode
+set -euo pipefail
+IFS=$'\n\t'
+
 # Change these two variables to override the defaults.
 # Load Threshold for doing a dump. Default is 50% of CPU for physical servers and a load average of 8 for virtual servers.
 THRESH=0  # <- Set to 0 so always generates a log for testing. - Alex Kr
@@ -69,20 +75,20 @@ readonly DIVIDER="=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 # within this directory, but is not required.
 if [ ! -d $DIR ]; then
   mkdir -p $DIR
-else
-  echo 'DEBUG: $DIR exists.' 1>&2
+#else
+#  echo 'DEBUG: $DIR exists.' 1>&2
 fi
 
 if [ ! -d $LOGDIR ]; then
   mkdir -p $LOGDIR
-else
-  echo 'DEBUG: $LOGDIR exists.' 1>&2
+#else
+#  echo 'DEBUG: $LOGDIR exists.' 1>&2
 fi
 
 # Gather the system stats and put them into the log.
 dump_stats() {
   echo -e "ALERT: Loadwatch Triggered! - Timestamp: ${DATE} - Load: ${LOAD} - Log: ${DIR}/${FILE}" >> $LOGDIR/$LOG
-  echo -e "=-=-=-=-=-=    BEGIN LOADWATCH REPORT - ${VERSION}  =-=-=-=-=-=\n" > $LOGDIR/$FILE
+  echo -e "=-=-=-=-=-=  BEGIN LOADWATCH REPORT - ${VERSION}  =-=-=-=-=-=\n" > $LOGDIR/$FILE
   echo $DATE >> $LOGDIR/$FILE
   echo $LOAD >> $LOGDIR/$FILE
   echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
@@ -93,7 +99,7 @@ dump_stats() {
   mysqladmin processlist stat >> $LOGDIR/$FILE
   echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
   echo "APACHE STATUS AND CONNECTIONS PER DOMAIN" >> $LOGDIR/$FILE
-  /usr/sbin/apachectl fullstatus | tee -a $LOGDIR/$FILE | awk '{print $14}' | sort |sed -e 's/^[[:blank:]]*#.*//' -e '/^[[:blank:]]*$/d' | uniq -c | sort -n | grep -v VHost >> $LOGDIR/$FILE
+  /usr/sbin/apachectl fullstatus | tee -a $LOGDIR/$FILE | awk '{print $14}' | sort | sed -e 's/^[[:blank:]]*#.*//' -e '/^[[:blank:]]*$/d' | uniq -c | sort -n | grep -v VHost >> $LOGDIR/$FILE
   echo -e "\n${DIVIDER}\n" >> $LOGDIR/$FILE
   echo "NETSTAT DETAILS" >> $LOGDIR/$FILE
   netstat -tn 2>/dev/null | grep :80 | awk '{print $5}' | cut -d: -f1 | sort | uniq -c | sort -nr | head >> $LOGDIR/$FILE
@@ -145,7 +151,6 @@ cleanup_files() {
     gzip -f -9 ${NEWLOG}
   fi
   find $LOGDIR -type f -name '${LOG.}*' -mtime +${RETEN} -exec rm -f {} \;
-
 }
 
 # Check for facter, needed to determine if system is physical or virtual. Abort if it's missing.


### PR DESCRIPTION
I put some work in on LoadWatch. I reformatted indentation in accordance with the google style for bash scripts. 2 spaces for tabs, tabs are spaces, etc. I also added MEM_THRESH variable and some logic for checking if MEM is over the MEM_THRESH. By default this is 50% for used memory. If triggered, a dump will be logged just like for CPU threshold. The default can be overridden at the top of the file by setting MEM_THRESH=value. There are some comments in the script for other things I changed, hopefully those are descriptive and seem like valid changes. I'm pretty sure I thoroughly tested all cases; hopefully I didn't miss anything. You'll see that I enabled "Bash Strict Mode" too, see related comment within script. Let me know if you have any questions or don't approve of anything for any reason. Thanks!